### PR TITLE
Link cleanup to ensure sidebar menu jumps to general signup settings

### DIFF
--- a/apps/studio/components/interfaces/Linter/Linter.utils.tsx
+++ b/apps/studio/components/interfaces/Linter/Linter.utils.tsx
@@ -165,7 +165,7 @@ export const lintInfoMap: LintInfo[] = [
     title: 'Auth OTP Long Expiry',
     icon: <Clock className="text-foreground-muted" size={15} strokeWidth={1} />,
     link: ({ orgRef, projectRef, branchRef }) =>
-      `/org/${orgRef}/project/${projectRef}/branch/${branchRef}/auth/providers`,
+      `/org/${orgRef}/project/${projectRef}/branch/${branchRef}/auth/signup`,
     linkText: 'View settings',
     docsLink: 'https://supabase.com/docs/guides/platform/going-into-prod#security',
     category: 'security',
@@ -175,7 +175,7 @@ export const lintInfoMap: LintInfo[] = [
     title: 'Auth OTP Short Length',
     icon: <Ruler className="text-foreground-muted" size={15} strokeWidth={1} />,
     link: ({ orgRef, projectRef, branchRef }) =>
-      `/org/${orgRef}/project/${projectRef}/branch/${branchRef}/auth/providers`,
+      `/org/${orgRef}/project/${projectRef}/branch/${branchRef}/auth/signup`,
     linkText: 'View settings',
     docsLink: 'https://supabase.com/docs/guides/platform/going-into-prod#security',
     category: 'security',

--- a/apps/studio/components/layouts/AuthLayout/Auth.Commands.tsx
+++ b/apps/studio/components/layouts/AuthLayout/Auth.Commands.tsx
@@ -51,7 +51,7 @@ export function useAuthGotoCommands(options?: CommandOptions) {
         id: 'nav-auth-providers',
         name: 'Providers',
         value: 'Auth: Providers (Social Login, SSO)',
-        route: `/org/${orgRef}/project/${projectRef}/branch/${branchRef}/auth/providers`,
+        route: `/org/${orgRef}/project/${projectRef}/branch/${branchRef}/auth/signup`,
         defaultHidden: true,
       },
       {
@@ -85,7 +85,7 @@ export function useAuthGotoCommands(options?: CommandOptions) {
       {
         id: 'nav-auth-mfa',
         name: 'Multi Factor Authentication (MFA)',
-        value: 'Auth: Multi Factor Authenticaiton (MFA)',
+        value: 'Auth: Multi Factor Authentication (MFA)',
         route: `/org/${orgRef}/project/${projectRef}/branch/${branchRef}/auth/mfa`,
         defaultHidden: true,
       },

--- a/apps/studio/components/layouts/AuthLayout/AuthLayout.utils.ts
+++ b/apps/studio/components/layouts/AuthLayout/AuthLayout.utils.ts
@@ -19,7 +19,7 @@ export const generateAuthMenu = (orgRef: string, projectRef: string, branchRef: 
           name: 'Sign Up / Providers',
           key: 'sign-in-up',
           pages: ['providers', 'third-party'],
-          url: `/org/${orgRef}/project/${projectRef}/branch/${branchRef}/auth/providers`,
+          url: `/org/${orgRef}/project/${projectRef}/branch/${branchRef}/auth/signup`,
           items: [],
         },
         {

--- a/apps/studio/components/layouts/ProjectSettingsLayout/ProjectSettings.Commands.tsx
+++ b/apps/studio/components/layouts/ProjectSettingsLayout/ProjectSettings.Commands.tsx
@@ -25,7 +25,7 @@ export function useProjectSettingsGotoCommands(options?: CommandOptions) {
       {
         id: 'nav-project-settings-auth',
         name: 'Auth Settings',
-        route: `/org/${orgRef}/project/${projectRef}/branch/${branchRef}/auth/providers`,
+        route: `/org/${orgRef}/project/${projectRef}/branch/${branchRef}/auth/signup`,
         defaultHidden: true,
       },
       {

--- a/apps/studio/pages/org/[slug]/project/[ref]/branch/[branch]/settings/auth.tsx
+++ b/apps/studio/pages/org/[slug]/project/[ref]/branch/[branch]/settings/auth.tsx
@@ -16,14 +16,14 @@ const ProjectSettings: NextPageWithLayout = () => {
           All settings are now under configuration within the Authentication page.
         </p>
         <Link
-          href={`/org/${orgRef}/project/${projectRef}/branch/${branchRef}/auth/providers`}
+          href={`/org/${orgRef}/project/${projectRef}/branch/${branchRef}/auth/signup`}
           className="py-2 hover:text-foreground border-b flex items-center justify-between"
         >
           General user signup
           <ChevronRight strokeWidth={1.5} size={16} />
         </Link>
         <Link
-          href={`/org/${orgRef}/project/${projectRef}/branch/${branchRef}/auth/providers`}
+          href={`/org/${orgRef}/project/${projectRef}/branch/${branchRef}/auth/signup`}
           className="py-2 hover:text-foreground border-b flex items-center justify-between"
         >
           Password settings in email provider


### PR DESCRIPTION
Clean up of uri paths after splitting auth providers and general signup config into separated tabs
