### PR TITLE
Fix last used branch redirect

### DIFF
--- a/apps/studio/data/branches/last-visited-branch.ts
+++ b/apps/studio/data/branches/last-visited-branch.ts
@@ -4,11 +4,15 @@ import { useBranchesQuery } from './branches-query'
 
 export function useLastVisitedBranch(project: ProjectDetail | undefined) {
   const lastBranchByProject = `last-branch-${project?.ref ?? 'unknown'}`
-  const { data: branches } = useBranchesQuery({orgSlug: project?.organization_id, projectRef: project?.id})
+  const { data: branches, isLoading } = useBranchesQuery({orgSlug: project?.organization_id, projectRef: project?.id})
   const mainBranch = branches?.find(branch => branch.name === project?.default_branch)
-  const [lastUsedBranch] = useLocalStorageQuery<string>(lastBranchByProject, mainBranch?.id ?? 'main')
-  if (lastUsedBranch !== 'main') {
-    return lastUsedBranch
+  const [lastUsedBranch] = useLocalStorageQuery<string>(lastBranchByProject, mainBranch?.id ?? '-')
+
+  if (isLoading) {
+    return { branchId: undefined, isLoading: true }
   }
-  return mainBranch?.id ?? 'main'
+  if (lastUsedBranch !== '-') {
+    return { branchId: lastUsedBranch, isLoading: false }
+  }
+  return { branchId: mainBranch?.id, isLoading: false }
 }

--- a/apps/studio/pages/org/[slug]/project/[ref]/index.tsx
+++ b/apps/studio/pages/org/[slug]/project/[ref]/index.tsx
@@ -19,17 +19,17 @@ const Home: NextPageWithLayout = () => {
   const { ref, slug } = useParams()
   const router = useRouter()
 
-  const [lastVisitedProjectBranch] = useLastVisitedBranch(project)
+  const { branchId: lastVisitedProjectBranch, isLoading: isBranchLoading } = useLastVisitedBranch(project)
 
   useEffect(() => {
-    if (isProjectLoading) return
+    if (isProjectLoading || isBranchLoading) return
 
     if (!project) {
       router.push('/organizations')
     } else {
       router.replace(`/org/${slug}/project/${ref}/branch/${lastVisitedProjectBranch}`)
     }
-  }, [router, project, isProjectLoading, lastVisitedProjectBranch, ref, slug])
+  }, [router, project, isProjectLoading, lastVisitedProjectBranch, isBranchLoading, ref, slug])
 
   return (
     <div className="w-full px-4">


### PR DESCRIPTION
This was redirecting to `/branches/m` since it unpacked the default return value of `main` as a collection. This change ensures that the `/branches` endpoint returns before redirecting.

The key that's looked up is never actually stored as far as I can tell, we'll have to do this in the future.