### PR TITLE
Integrate MFA

### DIFF
--- a/apps/studio/data/auth/auth-mfa-query.ts
+++ b/apps/studio/data/auth/auth-mfa-query.ts
@@ -1,0 +1,61 @@
+import { useQuery, useQueryClient, UseQueryOptions } from '@tanstack/react-query'
+import type { components } from 'data/api'
+import { get, handleError } from 'data/fetchers'
+import { useCallback } from 'react'
+import type { ResponseError } from 'types'
+import { authKeys } from './keys'
+
+export type AuthMFAVariables = {
+  orgId?: string
+  projectId?: string
+  branchId?: string
+}
+
+export async function getBranchAuthMFA(
+  { orgId, projectId, branchId }: AuthMFAVariables,
+  signal?: AbortSignal
+) {
+  const { data, error } = await get('/platform/organizations/{slug}/projects/{ref}/branches/{branch}/auth/config/mfa', {
+    params: {
+      path: {
+        slug: orgId!,
+        ref: projectId!,
+        branch: branchId!
+      },
+    },
+    signal,
+  })
+  if (error) handleError(error)
+  return data
+}
+
+export type BranchAuthMFAData = Awaited<ReturnType<typeof getBranchAuthMFA>>
+export type BranchAuthMFAError = ResponseError
+
+export const useAuthMFAQuery = <TData = BranchAuthMFAData>(
+  { orgId, projectId, branchId }: AuthMFAVariables,
+  {
+    enabled = true,
+    ...options
+  }: UseQueryOptions<BranchAuthMFAData, BranchAuthMFAError, TData> = {}
+) =>
+  useQuery<BranchAuthMFAData, BranchAuthMFAError, TData>(
+    authKeys.authMFA(orgId, projectId, branchId),
+    ({ signal }) => getBranchAuthMFA({ orgId, projectId, branchId }, signal),
+    {
+      enabled: enabled && typeof orgId !== 'undefined' && typeof projectId !== 'undefined' && typeof branchId !== 'undefined',
+      ...options,
+    }
+  )
+
+export const useAuthMFAPrefetch = ({ orgId, projectId, branchId }: AuthMFAVariables) => {
+  const client = useQueryClient()
+
+  return useCallback(() => {
+    if (projectId) {
+      client.prefetchQuery(authKeys.authMFA(orgId, projectId, branchId), ({ signal }) =>
+        getBranchAuthMFA({ orgId, projectId, branchId }, signal)
+      )
+    }
+  }, [client, orgId, projectId, branchId])
+}

--- a/apps/studio/data/auth/auth-mfa-update-mutation.ts
+++ b/apps/studio/data/auth/auth-mfa-update-mutation.ts
@@ -1,0 +1,72 @@
+import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import type { components } from 'data/api'
+import { handleError, put } from 'data/fetchers'
+import type { ResponseError } from 'types'
+import { authKeys } from './keys'
+
+export type AuthMFAUpdateVariables = {
+  orgId: string
+  projectId: string
+  branchId: string
+  status: 'enabled' | 'verify-enabled' | 'disabled'
+}
+
+export async function updateAuthMFA({
+  orgId,
+  projectId,
+  branchId,
+  status,
+}: AuthMFAUpdateVariables) {
+  const { data, error } = await put(
+    '/platform/organizations/{slug}/projects/{ref}/branches/{branch}/auth/config/mfa',
+    {
+      params: {
+        path: {
+          slug: orgId,
+          ref: projectId,
+          branch: branchId,
+        },
+      },
+      body: {
+        status: status,
+      },
+    }
+  )
+
+  if (error) handleError(error)
+  return data
+}
+
+type AuthMFAUpdateData = Awaited<ReturnType<typeof updateAuthMFA>>
+
+export const useAuthMFAUpdateMutation = ({
+  onSuccess,
+  onError,
+  ...options
+}: Omit<
+  UseMutationOptions<AuthMFAUpdateData, ResponseError, AuthMFAUpdateVariables>,
+  'mutationFn'
+> = {}) => {
+  const queryClient = useQueryClient()
+
+  return useMutation<AuthMFAUpdateData, ResponseError, AuthMFAUpdateVariables>(
+    (vars) => updateAuthMFA(vars),
+    {
+      async onSuccess(data, variables, context) {
+        const { orgId, projectId, branchId } = variables
+        await queryClient.invalidateQueries(authKeys.authMFA(orgId, projectId, branchId))
+        await onSuccess?.(data, variables, context)
+      },
+      async onError(data, variables, context) {
+        if (onError === undefined) {
+          toast.error(`Failed to update auth MFA configuration: ${data.message}`)
+        } else {
+          onError(data, variables, context)
+        }
+      },
+      ...options,
+    }
+  )
+}

--- a/apps/studio/data/auth/keys.ts
+++ b/apps/studio/data/auth/keys.ts
@@ -50,6 +50,11 @@ export const authKeys = {
     ] as const,
 
   authConfig: (projectRef: string | undefined) => ['projects', projectRef, 'auth-config'] as const,
+  authMFA: (
+    orgId: string | undefined,
+    projectId: string | undefined,
+    branchId: string | undefined,
+  ) => ['branches', orgId, projectId, branchId, 'mfa-config'] as const,
   accessToken: () => ['access-token'] as const,
   authProviders: (
     orgId: string | undefined,

--- a/apps/studio/pages/api/platform/organizations/[slug]/projects/[ref]/branches/[branch]/auth/config/mfa.ts
+++ b/apps/studio/pages/api/platform/organizations/[slug]/projects/[ref]/branches/[branch]/auth/config/mfa.ts
@@ -1,0 +1,119 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { apiBuilder } from 'lib/api/apiBuilder'
+import { getPlatformQueryParams } from 'lib/api/platformQueryParams'
+import { getVelaClient } from 'data/vela/vela'
+
+const handleGet = async (req: NextApiRequest, res: NextApiResponse) => {
+  const { slug, ref, branch } = getPlatformQueryParams(req, "slug", "ref", "branch")
+  const client = getVelaClient(req)
+
+  const { success: totp_success, data: totp_data } = await client.getOrFail(res, '/organizations/{organization_id}/projects/{project_id}/branches/{branch_id}/auth/authentication/required-actions/{alias}', {
+    params: {
+      path: {
+        organization_id: slug,
+        project_id: ref,
+        branch_id: branch,
+        alias: 'CONFIGURE_TOTP'
+      }
+    }
+  })
+
+  if (!totp_success) return;
+
+  const totp_enabled = totp_data.enabled;
+
+  const { success: flow_execution_success, data: flow_execution_data } = await client.getOrFail(res, '/organizations/{organization_id}/projects/{project_id}/branches/{branch_id}/auth/authentication/flows/{flowAlias}/executions', {
+    params: {
+      path: {
+        organization_id: slug,
+        project_id: ref,
+        branch_id: branch,
+        flowAlias: 'forms'
+      }
+    }
+  })
+
+  if (!flow_execution_success) return;
+
+  const totp_verification_requirement = flow_execution_data.find(step => step.providerId === 'auth-otp-form')?.requirement;
+  if (totp_verification_requirement !== 'ALTERNATIVE' && totp_verification_requirement !== 'DISABLED') return  // invalid state
+  const totp_verification_enabled = totp_verification_requirement === 'ALTERNATIVE'
+
+  if (totp_enabled && totp_verification_enabled) {
+    return res.json({status: 'enabled'})
+  } else if (!totp_enabled && totp_verification_enabled) {
+    return res.json({status: 'verify-enabled'})
+  } else if (!totp_enabled && !totp_verification_enabled) {
+    return res.json({status: 'disabled'})
+  } else {
+    return  // invalid state
+  }
+}
+
+const handlePut = async (req: NextApiRequest, res: NextApiResponse) => {
+  const { slug, ref, branch } = getPlatformQueryParams(req, "slug", "ref", "branch")
+  const client = getVelaClient(req)
+
+  const status = req.body.status
+  if (!status) return res.status(422).json({ message: 'Missing MFA status' })
+  if ((status !== 'enabled') && (status !== 'verify-enabled') && (status !== 'disabled')) return res.status(422).json({ message: 'Invalid MFA status' })
+
+  const totp_enabled = req.body.status === 'enabled'
+  const totp_verification_requirement = (req.body.status !== 'disabled') ? 'ALTERNATIVE' : 'DISABLED'
+
+  const { success: totp_success, data: totp_data } = await client.getOrFail(res, '/organizations/{organization_id}/projects/{project_id}/branches/{branch_id}/auth/authentication/required-actions/{alias}', {
+    params: {
+      path: {
+        organization_id: slug,
+        project_id: ref,
+        branch_id: branch,
+        alias: 'CONFIGURE_TOTP'
+      }
+    }
+  })
+  if (!totp_success) { return }
+
+
+  if (totp_data.enabled !== totp_enabled) {
+    const { success: totp_update_success } = await client.putOrFail(res, '/organizations/{organization_id}/projects/{project_id}/branches/{branch_id}/auth/authentication/required-actions/{alias}', {
+      params: {
+        path: {
+          organization_id: slug,
+          project_id: ref,
+          branch_id: branch,
+          alias: 'CONFIGURE_TOTP',
+        },
+      },
+      body: {
+        ...totp_data,
+        enabled: totp_enabled,
+      },
+    })
+    if (!totp_update_success) { return }
+  }
+
+  const flow_execution_step = flow_execution_data?.find(step => step.providerId === 'auth-otp-form')
+  if (flow_execution_step?.requirement !== totp_verification_requirement) {
+    const { success: totp_verification_update_success } = await client.putOrFail(res, '/organizations/{organization_id}/projects/{project_id}/branches/{branch_id}/auth/authentication/flows/{flowAlias}/executions', {
+      params: {
+        path: {
+          organization_id: slug,
+          project_id: ref,
+          branch_id: branch,
+          flowAlias: 'forms',
+        },
+      },
+      body: {
+        ...flow_execution_step,
+        requirement: totp_verification_requirement,
+      }
+    })
+    if (!totp_verification_update_success) { return }
+  }
+
+  return res.status(200).json({})
+}
+
+const apiHandler = apiBuilder(builder => builder.useAuth().get(handleGet).put(handlePut))
+
+export default apiHandler

--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -4,6 +4,22 @@
  */
 
 export interface paths {
+  '/platform/organizations/{slug}/projects/{ref}/branches/{branch}/auth/config/mfa': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    },
+    get: operations['BranchAuthController_getMFA']
+    put: operations['BranchAuthController_updateMFA']
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  },
   '/platform/organizations/{slug}/projects/{ref}/branches/{branch}/auth/config/client': {
     parameters: {
       query?: never
@@ -4580,6 +4596,9 @@ export interface components {
         userInfoUrl?: string
         [key: string]: string;
       };
+    }
+    BranchAuthMFAConfig: {
+      status: 'enabled' | 'verify-enabled' | 'disabled';
     }
     BranchAuthClientResponse: {
       id?: string;
@@ -9721,6 +9740,68 @@ export interface operations {
       }
       /** @description Failed to update GoTrue config hooks */
       500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  },
+  BranchAuthController_getMFA: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        slug: string
+        ref: string
+        branch: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['BranchAuthMFAConfig']
+        }
+      }
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  },
+  BranchAuthController_updateMFA: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        slug: string
+        ref: string
+        branch: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['BranchAuthMFAConfig']
+      }
+    }
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': {}
+        }
+      }
+      403: {
         headers: {
           [name: string]: unknown
         }


### PR DESCRIPTION
This integrates the Keycloak MFA settings:
- (for now) removes SMS 2FA configuration
- removes the limit on number of factors, there is no corresponding setting in Keycloak
- integrated the configuration of TOTP factors:
  - Enabled: TOTP factors can be configured, and the are checked
  - Verify Enabled: TOTP factors are checked, but cannot be configured
  - Disabled: Neither configuration nor verification of TOTP factors is conducted.
