### PR TITLE
Support for logging out from next-auth and Keycloak in a multistep process

### DIFF
--- a/apps/studio/.env
+++ b/apps/studio/.env
@@ -27,7 +27,7 @@ VELA_PLATFORM_KEYCLOAK_CLIENT_SECRET=super-long-random-keycloak-secret
 VELA_PLATFORM_KEYCLOAK_AUTHORIZATION_ENDPOINT=http://localhost:8000/auth/realms/vela/protocol/openid-connect/auth
 VELA_PLATFORM_KEYCLOAK_TOKEN_ENDPOINT=http://auth:8080/auth/realms/vela/protocol/openid-connect/token
 VELA_PLATFORM_KEYCLOAK_USERINFO_ENDPOINT=http://auth:8080/auth/realms/vela/protocol/openid-connect/userinfo
-VELA_PLATFORM_KEYCLOAK_LOGOUT_ENDPOINT=http://auth:8080/auth/protocol/openid-connect/logout
+VELA_PLATFORM_KEYCLOAK_LOGOUT_ENDPOINT=http://localhost:8000/auth/realms/vela/protocol/openid-connect/logout
 VELA_PLATFORM_KEYCLOAK_JWKS_ENDPOINT=http://auth:8080/auth/realms/vela/protocol/openid-connect/certs
 VELA_PLATFORM_DEV_MODE=true
 

--- a/apps/studio/lib/auth.tsx
+++ b/apps/studio/lib/auth.tsx
@@ -1,14 +1,9 @@
-import { useQueryClient } from '@tanstack/react-query'
-import {
-  AuthProvider as AuthProviderInternal,
-  clearLocalStorage, signOut,
-  useAuthError,
-} from 'common'
 import { PropsWithChildren, useCallback, useEffect } from 'react'
 import { toast } from 'sonner'
 
 import { GOTRUE_ERRORS } from './constants'
 import { SessionProvider } from 'next-auth/react'
+import { AuthProvider as AuthProviderInternal, signOut, useAuthError } from 'common'
 
 const AuthErrorToaster = ({ children }: PropsWithChildren) => {
   const error = useAuthError()
@@ -43,13 +38,8 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
 export { useAuth, useIsLoggedIn, useSession, useUser } from 'common'
 
 export function useSignOut() {
-  const queryClient = useQueryClient()
-
   return useCallback(async () => {
-    const result = await signOut()
-    clearLocalStorage()
-    // Clear Assistant IndexedDB
-    queryClient.clear()
-    return result
-  }, [queryClient])
+    // Run full sign out cycle
+    return await signOut()
+  }, [signOut])
 }

--- a/apps/studio/pages/api/auth/logout.ts
+++ b/apps/studio/pages/api/auth/logout.ts
@@ -1,0 +1,29 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { getKeycloakManager } from 'common/keycloak'
+import { apiBuilder } from 'lib/api/apiBuilder'
+
+const logoutEndpoint = process.env.VELA_PLATFORM_KEYCLOAK_LOGOUT_ENDPOINT
+if (!logoutEndpoint) {
+  throw new Error('VELA_PLATFORM_KEYCLOAK_LOGOUT_ENDPOINT is not set')
+}
+
+const keycloakManager = getKeycloakManager()
+
+const handlePost = async (req: NextApiRequest, res: NextApiResponse) => {
+  const session = await keycloakManager.getSession(req,res)
+  if (!session) {
+    return res.json({ error: "No session found"})
+  }
+
+  const idToken = session.id_token
+  if (!idToken) {
+    return res.json({ error: "No id_token found in session"})
+  }
+  const url = new URL(logoutEndpoint)
+  url.searchParams.set("id_token_hint", session.id_token);
+  return res.json({ logoutEndpoint: url.toString() })
+}
+
+const apiHandler = apiBuilder(builder => builder.post(handlePost))
+
+export default apiHandler

--- a/apps/studio/pages/logout.tsx
+++ b/apps/studio/pages/logout.tsx
@@ -5,14 +5,21 @@ import { toast } from 'sonner'
 import { Loading } from 'components/ui/Loading'
 import { useSignOut } from 'lib/auth'
 import { NextPageWithLayout } from 'types'
+import { useQueryClient } from '@tanstack/react-query'
+import { clearLocalStorage } from 'common'
 
 const LogoutPage: NextPageWithLayout = () => {
   const router = useRouter()
-  const signOut = useSignOut()
+  const queryClient = useQueryClient()
 
   useEffect(() => {
     const logout = async () => {
-      await signOut()
+      // Clear local storage
+      clearLocalStorage()
+      // Clear Assistant IndexedDB
+      queryClient.clear()
+
+      // Successful and send back to sign-in
       toast('Successfully logged out')
       await router.push('/sign-in')
     }

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -54,7 +54,7 @@ services:
       VELA_PLATFORM_KEYCLOAK_AUTHORIZATION_ENDPOINT: http://localhost:8000/auth/realms/vela/protocol/openid-connect/auth
       VELA_PLATFORM_KEYCLOAK_TOKEN_ENDPOINT: http://auth:8080/auth/realms/vela/protocol/openid-connect/token
       VELA_PLATFORM_KEYCLOAK_USERINFO_ENDPOINT: http://auth:8080/auth/realms/vela/protocol/openid-connect/userinfo
-      VELA_PLATFORM_KEYCLOAK_LOGOUT_ENDPOINT: http://auth:8080/auth/protocol/openid-connect/logout
+      VELA_PLATFORM_KEYCLOAK_LOGOUT_ENDPOINT: http://localhost:8000/auth/realms/vela/protocol/openid-connect/logout
       VELA_PLATFORM_KEYCLOAK_JWKS_ENDPOINT: http://auth:8080/auth/realms/vela/protocol/openid-connect/certs
       VELA_PLATFORM_EXT_SIGN_IN_URL: http://localhost:8000/sign-in
       VELA_PLATFORM_EXT_BASE_URL: http://localhost:8000/

--- a/docker/volumes/auth/realm.json
+++ b/docker/volumes/auth/realm.json
@@ -43,7 +43,10 @@
       "standardFlowEnabled": true,
       "directAccessGrantsEnabled": true,
       "publicClient": true,
-      "protocol": "openid-connect"
+      "protocol": "openid-connect",
+      "attributes": {
+        "post.logout.redirect.uris": "http://localhost:8000/logout##http://localhost:3000/logout"
+      }
     },
     {
       "clientId": "controller",


### PR DESCRIPTION
This PR adds the necessary configuration changes to ensure Vela-Studio can successfully logout from Keycloak in a multistep process:

- Vela-Studio:
  - Retrieve id_token from session
  - Build logout url for Keycloak
  - Destroy next-auth session
  - Redirect the user to the Keycloak logout url
  - Redirect the user to https://staging.vela.run/