### PR TITLE
Exchanged ?jwt=... with ?auth_token=...

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.utils.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/NavigationBar/NavigationBar.utils.tsx
@@ -243,7 +243,7 @@ export const generateOtherRoutes = (
             key: 'grafana',
             label: 'Monitoring',
             icon: <SearchCheck size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
-            link: `${monitoringEndpoint}?jwt=${accessToken}`,
+            link: `${monitoringEndpoint}?auth_token=${accessToken}`,
             target: '_blank',
           },
         ]


### PR DESCRIPTION
This PR exchanged the wrong query parameter jwt for auth_token (as defined in the Grafana documentation).