### PR TITLE
deploy.yml: notify vela controller only on success

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   dispatch:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Send repository_dispatch event


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

If the current build fails, it still notify the Vela Controller to deploy the image which results in image pull error. 

## What is the new behavior?

notification to Vela is sent only on success. 

## Additional context

-
