### PR TITLE
change event hook to build upon completion of Build and publish image

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -3,7 +3,7 @@ name: Notify vela controller repo (Development)
 on:
   workflow_run:
     branches: [dev]
-    workflows: ['Deploy Vela Studio to Dev']
+    workflows: ['Build and publish image']
     types:
       - completed
 


### PR DESCRIPTION
the workflow `Build and publish image` already has change to build and push to dev tag. So changing the event hook to act based on that. 