### PR TITLE
push tagged dev images

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -139,6 +139,8 @@ jobs:
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=latest-{{sha}},enable={{is_default_branch}}
+            type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
+            type=raw,value=dev-{{sha}},enable=${{ github.ref == 'refs/heads/dev' }}
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}


### PR DESCRIPTION
push both `dev` and `dev-<short-sha>` tags. 

Also updating the vela controller to pick and use the images based on environment. 
https://github.com/simplyblock/vela-controller/pull/601