### PR TITLE
Drop use of old resource endpoints in project and org overviews

### DIFF
--- a/apps/studio/components/interfaces/Organization/OrganizationResourcesPanel.tsx
+++ b/apps/studio/components/interfaces/Organization/OrganizationResourcesPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react'
-import { useOrganizationLimitsQuery } from 'data/resource-limits/organization-limits-query'
 import { useOrganizationAllocationsQuery } from 'data/resource-limits/organization-allocations-query'
+import { useOrgAvailableCreationResourcesQuery } from 'data/resource-limits/org-available-creation-resources-query'
 import { cn } from 'ui'
 import { divideValue, formatResource } from '../Project/utils'
 
@@ -27,24 +27,28 @@ const RESOURCE_DEFS: Array<{
  * Reads organization-wide limits and allocations and renders usage bars.
  */
 export default function OrganizationResourcesPanel({ orgRef }: Props) {
-  const { data: limits, isLoading: loadingLimits } = useOrganizationLimitsQuery(
-    { orgRef },
-    { enabled: !!orgRef }
-  )
-
   const { data: allocations, isLoading: loadingAllocations } = useOrganizationAllocationsQuery(
     { orgRef },
     { enabled: !!orgRef }
   )
 
-  const loading = loadingLimits || loadingAllocations
+  const { data: available, isLoading: loadingAvailable } = useOrgAvailableCreationResourcesQuery(
+    { orgId: orgRef },
+    { enabled: !!orgRef }
+  )
+
+  const loading = loadingAllocations || loadingAvailable
 
   const rows = useMemo(() => {
-    if (!limits && !allocations) return []
+    if (!allocations && !available) return []
 
     return RESOURCE_DEFS.map((def) => {
-      const maxRaw = limits?.total?.[def.key] ?? null
-      const allocatedRaw = allocations?.[def.key] ?? null
+      const allocatedRaw =
+        typeof allocations?.[def.key] === 'number' ? (allocations[def.key] as number) : null
+      const availableRaw =
+        typeof available?.[def.key] === 'number' ? (available[def.key] as number) : null
+      // max = allocations + available gives the effective system-derived total
+      const maxRaw = allocatedRaw != null && availableRaw != null ? allocatedRaw + availableRaw : null
 
       const maxDisplayNumber = maxRaw == null ? null : divideValue(def.key, maxRaw)
       const allocatedDisplayNumber = divideValue(def.key, allocatedRaw) ?? 0
@@ -65,7 +69,7 @@ export default function OrganizationResourcesPanel({ orgRef }: Props) {
         colorClass: def.colorClass,
       }
     }).filter((row) => (row.allocatedRaw !== null || row.maxRaw !== null) && row.maxRaw !== 0)
-  }, [limits, allocations])
+  }, [allocations, available])
 
   const mostAllocated =
     rows

--- a/apps/studio/components/interfaces/Project/ProjectResourcesBadge.tsx
+++ b/apps/studio/components/interfaces/Project/ProjectResourcesBadge.tsx
@@ -1,14 +1,13 @@
 import React, { useMemo } from 'react'
 import { Tooltip, TooltipTrigger, TooltipContent, cn } from 'ui'
-import { useProjectLimitsQuery, type ProjectLimitsData } from 'data/resource-limits/project-limits-query'
+import { useProjectAllocationsQuery } from 'data/resource-limits/project-allocations-query'
 import {
   useProjectAvailableCreationResourcesQuery,
   type ProjectAvailableCreationResourcesData,
 } from 'data/resource-limits/project-available-creation-resources-query'
 import { divideValue, formatResource } from './utils'
 
-type ProjectLimitItem = NonNullable<ProjectLimitsData>[number]
-type ProjectAllocationKey = keyof ProjectAvailableCreationResourcesData 
+type ProjectAllocationKey = keyof ProjectAvailableCreationResourcesData
 const RESOURCE_DEFS: Array<{
   key: ProjectAllocationKey
   label: string
@@ -22,7 +21,7 @@ const RESOURCE_DEFS: Array<{
 
 /**
  * Shows project resource allocation.
- * Allocation is computed as: max_total - available.
+ * Max is computed as: allocations + available.
  */
 export const ProjectResourcesBadge = ({
   orgRef,
@@ -33,7 +32,7 @@ export const ProjectResourcesBadge = ({
   projectRef?: string
   size?: number
 }) => {
-  const limitsQuery = useProjectLimitsQuery(
+  const allocationsQuery = useProjectAllocationsQuery(
     { orgRef: orgRef!, projectRef: projectRef! },
     { enabled: !!orgRef && !!projectRef }
   )
@@ -47,22 +46,20 @@ export const ProjectResourcesBadge = ({
   )
 
   const rows = useMemo(() => {
-    const limitsData = limitsQuery.data
+    const allocationsData = allocationsQuery.data
     const availableData = availableQuery.data
 
-    if (!limitsData && !availableData) return []
+    if (!allocationsData && !availableData) return []
 
     return RESOURCE_DEFS.map((def) => {
-      const limitEntry = Array.isArray(limitsData)
-        ? limitsData.find((limit: ProjectLimitItem) => limit.resource === def.key)
-        : undefined
-      if (!limitEntry) return null
-      const maxRaw = typeof limitEntry?.max_total === 'number' ? limitEntry.max_total : null
-
-      const availableValue = availableData?.[def.key]
-      const availableRaw = typeof availableValue === 'number' ? availableValue : 0
-
-      const allocatedRaw = maxRaw == null ? null : Math.max(0, maxRaw - availableRaw)
+      const allocatedRaw =
+        typeof (allocationsData as Record<string, unknown>)?.[def.key] === 'number'
+          ? ((allocationsData as Record<string, unknown>)[def.key] as number)
+          : null
+      const availableRaw =
+        typeof availableData?.[def.key] === 'number' ? (availableData[def.key] as number) : null
+      const maxRaw =
+        allocatedRaw != null && availableRaw != null ? allocatedRaw + availableRaw : null
 
       const maxDisplayNumber = maxRaw == null ? null : divideValue(def.key, maxRaw)
       const allocatedDisplayNumber = divideValue(def.key, allocatedRaw) ?? 0
@@ -78,10 +75,10 @@ export const ProjectResourcesBadge = ({
         percent,
         allocatedDisplay: formatResource(def.key, allocatedRaw),
         maxDisplay: maxRaw == null ? 'unlimited' : formatResource(def.key, maxRaw),
-        hasData: allocatedRaw !== null || maxRaw !== null,
+        hasData: (allocatedRaw !== null || maxRaw !== null) && maxRaw !== 0,
       }
-    }).filter((row): row is NonNullable<typeof row> => row !== null && row.hasData)
-  }, [limitsQuery.data, availableQuery.data])
+    }).filter((row): row is NonNullable<typeof row> => row.hasData)
+  }, [allocationsQuery.data, availableQuery.data])
 
   const mostAllocated = useMemo(() => {
     if (rows.length === 0) return null
@@ -113,7 +110,7 @@ export const ProjectResourcesBadge = ({
     }
   }
 
-  const loading = limitsQuery.isLoading || availableQuery.isLoading
+  const loading = allocationsQuery.isLoading || availableQuery.isLoading
   const empty = rows.length === 0 && !loading
 
   return (
@@ -157,7 +154,7 @@ export const ProjectResourcesBadge = ({
 
       <TooltipContent side="top" align="center" className="min-w-[240px] p-3">
         <div className="space-y-2">
-          <div className="text-xs text-foreground-muted">Project resource allocation (limits - available)</div>
+          <div className="text-xs text-foreground-muted">Project resource allocation</div>
 
           {loading ? (
             <div className="text-sm text-foreground-light">Loading allocation...</div>

--- a/apps/studio/components/interfaces/Project/ProjectResourcesPanel.tsx
+++ b/apps/studio/components/interfaces/Project/ProjectResourcesPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react'
-import { useProjectLimitsQuery } from 'data/resource-limits/project-limits-query'
 import { useProjectAllocationsQuery } from 'data/resource-limits/project-allocations-query'
+import { useProjectAvailableCreationResourcesQuery } from 'data/resource-limits/project-available-creation-resources-query'
 import { cn } from 'ui'
 import { divideValue, formatResource } from './utils'
 
@@ -27,24 +27,28 @@ const RESOURCE_DEFS: Array<{
  * Panel that shows project-wide allocations.
  */
 export default function ProjectResourcesPanel({ orgRef, projectRef }: Props) {
-  const { data: limits, isLoading: loadingLimits } = useProjectLimitsQuery(
-    { orgRef, projectRef },
-    { enabled: !!orgRef && !!projectRef }
-  )
-
   const { data: allocations, isLoading: loadingAllocations } = useProjectAllocationsQuery(
     { orgRef, projectRef },
     { enabled: !!orgRef && !!projectRef }
   )
 
-  const loading = loadingLimits || loadingAllocations
+  const { data: available, isLoading: loadingAvailable } = useProjectAvailableCreationResourcesQuery(
+    { orgId: orgRef, projectId: projectRef },
+    { enabled: !!orgRef && !!projectRef }
+  )
+
+  const loading = loadingAllocations || loadingAvailable
 
   const rows = useMemo(() => {
-    if (!limits && !allocations) return []
+    if (!allocations && !available) return []
 
     return RESOURCE_DEFS.map((def) => {
-      const maxRaw = limits?.total?.[def.key] ?? null
-      const allocatedRaw = allocations?.[def.key] ?? null
+      const allocatedRaw =
+        typeof allocations?.[def.key] === 'number' ? (allocations[def.key] as number) : null
+      const availableRaw =
+        typeof available?.[def.key] === 'number' ? (available[def.key] as number) : null
+      // max = allocations + available gives the effective system-derived total
+      const maxRaw = allocatedRaw != null && availableRaw != null ? allocatedRaw + availableRaw : null
 
       const maxDisplayNumber = maxRaw == null ? null : divideValue(def.key, maxRaw)
       const allocatedDisplayNumber = divideValue(def.key, allocatedRaw) ?? 0
@@ -65,7 +69,7 @@ export default function ProjectResourcesPanel({ orgRef, projectRef }: Props) {
         colorClass: def.colorClass,
       }
     }).filter((row) => (row.allocatedRaw !== null || row.maxRaw !== null) && row.maxRaw !== 0)
-  }, [limits, allocations])
+  }, [allocations, available])
 
   const mostAllocated =
     rows

--- a/apps/studio/pages/new/[slug]/index.tsx
+++ b/apps/studio/pages/new/[slug]/index.tsx
@@ -45,7 +45,9 @@ import { getPathReferences } from 'data/vela/path-references'
 import { useCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import WideWizardLayout from 'components/layouts/WideWizardLayout'
 import { components } from 'data/vela/vela-schema'
+import { useOrgAvailableCreationResourcesQuery } from 'data/resource-limits/org-available-creation-resources-query'
 import { useOrganizationLimitsQuery } from 'data/resource-limits/organization-limits-query'
+import { put } from 'data/fetchers'
 import { calculateSliderDefault } from '../../../lib/slider-helpers'
 
 /* ------------------------------------------------------------------ */
@@ -227,10 +229,13 @@ const CreateProjectPage: NextPageWithLayout = () => {
 
   const { data: systemLimitDefinitions } = useResourceLimitDefinitionsQuery()
 
-  // Dynamic limit definitions
-  const { data: limitDefinitions } = useOrganizationLimitsQuery({
-    orgRef: slug,
+  // Dynamic limit definitions: use available resources (reflects system limits when no org override)
+  const { data: limitDefinitions } = useOrgAvailableCreationResourcesQuery({
+    orgId: slug,
   })
+
+  // Check whether the org has explicitly configured limits (to decide if we need to set them on submit)
+  const { data: orgLimits } = useOrganizationLimitsQuery({ orgRef: slug })
 
   // Build dynamic limitConfig from API
   const limitConfig: LimitMap | null = useMemo(() => {
@@ -244,7 +249,7 @@ const CreateProjectPage: NextPageWithLayout = () => {
     map['vcpu'] = {
       label: LABELS['vcpu'],
       min: (vcpuDef?.min ?? 0) / vcpuDivider,
-      max: (limitDefinitions.total.milli_vcpu ?? 0) / vcpuDivider,
+      max: (limitDefinitions.milli_vcpu ?? 0) / vcpuDivider,
       step: (vcpuDef?.step ?? 100) / vcpuDivider,
       unit: 'vCPU',
       divider: vcpuDivider,
@@ -255,7 +260,7 @@ const CreateProjectPage: NextPageWithLayout = () => {
     map['ram'] = {
       label: LABELS['ram'],
       min: (ramDef?.min ?? 0) / ramDivider,
-      max: (limitDefinitions.total.ram ?? 0) / ramDivider,
+      max: (limitDefinitions.ram ?? 0) / ramDivider,
       step: (ramDef?.step ?? 256 * 1024 * 1024) / ramDivider,
       unit: 'GiB',
       divider: ramDivider,
@@ -265,7 +270,7 @@ const CreateProjectPage: NextPageWithLayout = () => {
     map['iops'] = {
       label: LABELS['iops'],
       min: iopsDef?.min ?? 0,
-      max: limitDefinitions.total.iops ?? 0,
+      max: limitDefinitions.iops ?? 0,
       step: iopsDef?.step ?? 100,
       unit: 'IOPS',
       divider: 1,
@@ -276,19 +281,19 @@ const CreateProjectPage: NextPageWithLayout = () => {
     map['nvme'] = {
       label: LABELS['nvme'],
       min: (nvmeDef?.min ?? 0) / nvmeDivider,
-      max: (limitDefinitions.total.database_size ?? 0) / nvmeDivider,
+      max: (limitDefinitions.database_size ?? 0) / nvmeDivider,
       step: (nvmeDef?.step ?? nvmeDivider) / nvmeDivider,
       unit: 'GB',
       divider: nvmeDivider,
     }
 
-    if ((limitDefinitions.total.storage_size ?? 0) > 0) {
+    if ((limitDefinitions.storage_size ?? 0) > 0) {
       const storageDef = systemLimitDefinitions.find(l => l.resource_type === 'storage_size')
       const storageDivider = 1_000_000_000 // 1 GB
       map['storage'] = {
         label: LABELS['storage'],
         min: (storageDef?.min ?? 0) / storageDivider,
-        max: (limitDefinitions.total.storage_size ?? 0) / storageDivider,
+        max: (limitDefinitions.storage_size ?? 0) / storageDivider,
         step: (storageDef?.step ?? storageDivider) / storageDivider,
         unit: 'GB',
         divider: storageDivider,
@@ -574,6 +579,42 @@ const CreateProjectPage: NextPageWithLayout = () => {
     if (!values.includeFileStorage && sliderKeys.includes('storage')) {
       per_branch_limits.storage_size = 0
       project_limits.storage_size = 0
+    }
+
+    // If org has no configured limits (all null), set them from available resources so the
+    // controller can validate project limits against an org ceiling.
+    const orgLimitsUnconfigured =
+      limitDefinitions != null &&
+      orgLimits?.total != null &&
+      Object.values(orgLimits.total).every((v) => v == null)
+    if (orgLimitsUnconfigured) {
+      const { error: limitsError } = await put(
+        '/platform/organizations/{slug}/resources/limits',
+        {
+          params: { path: { slug: currentOrg.id! } },
+          body: {
+            total: {
+              milli_vcpu: limitDefinitions.milli_vcpu ?? null,
+              ram: limitDefinitions.ram ?? null,
+              iops: limitDefinitions.iops ?? null,
+              database_size: limitDefinitions.database_size ?? null,
+              storage_size: limitDefinitions.storage_size ?? null,
+            },
+            // per_branch uses the per-branch slider values from the form
+            per_branch: {
+              milli_vcpu: per_branch_limits['milli_vcpu'] ?? null,
+              ram: per_branch_limits['ram'] ?? null,
+              iops: per_branch_limits['iops'] ?? null,
+              database_size: per_branch_limits['database_size'] ?? null,
+              storage_size: per_branch_limits['storage_size'] ?? null,
+            },
+          } as any,
+        }
+      )
+      if (limitsError) {
+        toast.error('Failed to configure organization limits. Please try again.')
+        return
+      }
     }
 
     const data: ProjectCreateVariables = {


### PR DESCRIPTION
This corresponds to changes in #260, there were still deprecated endpoints being used.