### PR TITLE
Introduce helper for consistently displaying data size units

### DIFF
--- a/apps/studio/components/interfaces/Branch/ResizeBranchModal.tsx
+++ b/apps/studio/components/interfaces/Branch/ResizeBranchModal.tsx
@@ -16,6 +16,7 @@ import {
 } from 'ui'
 import { toast } from 'sonner'
 
+import { formatBytes } from 'lib/helpers'
 import {
   useBranchSliderResourceLimits,
   SliderSpecification,
@@ -125,6 +126,17 @@ export const BranchResizeModal: React.FC<Props> = ({
     return apiVal / s.divider
   }
 
+  // helper: format raw API bytes/millis -> human-readable string with unit
+  const formatCurrentValue = (rk: ResourceType, raw: number | null | undefined): string => {
+    if (raw == null) return '—'
+    if (rk === 'ram') return formatBytes(raw, 'binary')
+    if (rk === 'database_size' || rk === 'storage_size') return formatBytes(raw, 'decimal')
+    // non-byte resources: use existing divider + unit
+    const s = sliderSpecs[rk]
+    if (!s) return '—'
+    const val = raw / s.divider
+    return `${val % 1 === 0 ? val.toFixed(0) : val.toFixed(1)} ${s.unit}`
+  }
   const getEffectiveMax = (rk: ResourceType, s: SliderSpecification): number => {
     let maxFromSpec = s.max
 
@@ -389,22 +401,17 @@ const getEffectiveMin = (rk: ResourceType, s: SliderSpecification): number => {
     const s = sliderSpecs[rk]
     if (!s) return null
 
-    const currentDisplay = (() => {
+    const rawForRk = (() => {
       switch (rk) {
-        case 'milli_vcpu':
-          return apiToDisplay('milli_vcpu', branchMax?.milli_vcpu ?? null)
-        case 'ram':
-          return apiToDisplay('ram', branchMax?.ram_bytes ?? null)
-        case 'iops':
-          return apiToDisplay('iops', branchMax?.iops ?? null)
-        case 'database_size':
-          return apiToDisplay('database_size', branchMax?.nvme_bytes ?? null)
-        case 'storage_size':
-          return hasStorage ? apiToDisplay('storage_size', branchMax?.storage_bytes ?? null) : undefined
-        default:
-          return undefined
+        case 'milli_vcpu': return branchMax?.milli_vcpu ?? null
+        case 'ram': return branchMax?.ram_bytes ?? null
+        case 'iops': return branchMax?.iops ?? null
+        case 'database_size': return branchMax?.nvme_bytes ?? null
+        case 'storage_size': return hasStorage ? (branchMax?.storage_bytes ?? null) : null
+        default: return null
       }
     })()
+    const currentDisplay = formatCurrentValue(rk, rawForRk)
 
     const value = watch(rk as keyof FormValues) as number
     const effectiveMin = getEffectiveMin(rk, s)
@@ -421,9 +428,8 @@ const getEffectiveMin = (rk: ResourceType, s: SliderSpecification): number => {
             <div className="text-[11px] text-foreground-muted font-mono">
               Current:{' '}
               <span className="inline-block w-20 text-right">
-                {currentDisplay ?? '—'}
-              </span>{' '}
-              {s.unit}
+                {currentDisplay}
+              </span>
             </div>
             <div className="text-[11px] text-foreground-muted font-mono">
               New:{' '}

--- a/apps/studio/components/interfaces/Branch/utils.ts
+++ b/apps/studio/components/interfaces/Branch/utils.ts
@@ -1,3 +1,5 @@
+import { formatBytes } from 'lib/helpers'
+
 // lib/resource-utils.ts
 export type ResourceKey =
   | 'milli_vcpu'
@@ -56,13 +58,11 @@ export function formatForUnit(
   }
 
   if (unitKey === 'ram' || unitKey === 'ram_bytes') {
-    // GiB
-    return v < 10 ? `${v.toFixed(2)} GiB` : `${Math.round(v)} GiB`
+    return formatBytes(raw, 'binary', v < 10 ? 2 : 0)
   }
 
   if (unitKey === 'nvme_bytes' || unitKey === 'database_size' || unitKey === 'storage_bytes' || unitKey === 'storage_size') {
-    // GB decimal
-    return v < 10 ? `${v.toFixed(2)} GB` : `${Math.round(v)} GB`
+    return formatBytes(raw, 'decimal', v < 10 ? 2 : 0)
   }
 
   // iops or fallback numeric

--- a/apps/studio/components/interfaces/Database/Backups/Branch/BranchBackups.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/Branch/BranchBackups.tsx
@@ -277,7 +277,7 @@ const BranchBackups = () => {
                                   </TableCell>
                                   <TableCell className="text-right text-sm text-foreground-light">
                                     {typeof backup.sizeBytes === 'number'
-                                      ? formatBytes(backup.sizeBytes, 2)
+                                      ? formatBytes(backup.sizeBytes, 'decimal', 2)
                                       : '—'}
                                   </TableCell>
                                   <TableCell className="text-right">

--- a/apps/studio/components/interfaces/DiskManagement/ui/DiskSpaceBar.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/ui/DiskSpaceBar.tsx
@@ -81,8 +81,8 @@ export default function DiskSpaceBar({ form }: DiskSpaceBarProps) {
     <div className="flex flex-col gap-2">
       <div className="flex items-center h-6 gap-3">
         <span className="text-foreground-light text-sm font-mono flex items-center gap-2">
-          {usedSizeTotal.toFixed(2)}
-          <span>GB used of </span>
+          {formatBytes(diskBreakdownBytes.totalUsedBytes, 'decimal')}
+          <span>used of </span>
           <span className="text-foreground font-semibold -mt-[2px]">
             <MotionNumber value={newTotalSize} style={{ lineHeight: 0.8 }} className="font-mono" />
           </span>{' '}
@@ -237,10 +237,10 @@ export default function DiskSpaceBar({ form }: DiskSpaceBarProps) {
       <p className="text-xs text-foreground-lighter my-4">
         <span className="font-semibold">Note:</span> Disk Size refers to the total space your
         project occupies on disk, including the database itself (currently{' '}
-        <span>{formatBytes(diskBreakdownBytes?.dbSizeBytes, 2, 'GB')}</span>), additional files like
+        <span>{formatBytes(diskBreakdownBytes?.dbSizeBytes, 'decimal', 2, 'GB')}</span>), additional files like
         the write-ahead log (currently{' '}
-        <span>{formatBytes(diskBreakdownBytes?.walSizeBytes, 2, 'GB')}</span>), and other system
-        resources (currently <span>{formatBytes(diskBreakdownBytes?.systemBytes, 2, 'GB')}</span>).
+        <span>{formatBytes(diskBreakdownBytes?.walSizeBytes, 'decimal', 2, 'GB')}</span>), and other system
+        resources (currently <span>{formatBytes(diskBreakdownBytes?.systemBytes, 'decimal', 2, 'GB')}</span>).
         Data can take 5 minutes to refresh.
       </p>
     </div>
@@ -269,7 +269,7 @@ const LegendItem = ({
       <div className="flex items-center">
         <div className={cn('w-2 h-2 rounded-full mr-2', color)} />
         <span>
-          {name} - {formatBytes(size, 2, 'GB')}
+          {name} - {formatBytes(size, 'decimal', 2, 'GB')}
         </span>
       </div>
       <p>{description}</p>

--- a/apps/studio/components/interfaces/Organization/Backups/BackupsHistoryDialog.tsx
+++ b/apps/studio/components/interfaces/Organization/Backups/BackupsHistoryDialog.tsx
@@ -80,7 +80,7 @@ export const BackupsHistoryDialog = ({
                   </TableCell>
                   <TableCell className="text-sm text-foreground-light">
                     {typeof backup.sizeBytes === 'number'
-                      ? formatBytes(backup.sizeBytes, 2)
+                      ? formatBytes(backup.sizeBytes, 'decimal', 2)
                       : '—'}
                   </TableCell>
                   <TableCell>

--- a/apps/studio/components/interfaces/Organization/Backups/BackupsTable.tsx
+++ b/apps/studio/components/interfaces/Organization/Backups/BackupsTable.tsx
@@ -73,7 +73,7 @@ export const BackupsTable = ({ rows, onDisable, onEnable, onViewBackups }: Backu
 
         <TableCell className="text-right text-sm text-foreground-light">
           {typeof row.storageUsedBytes === 'number'
-            ? formatBytes(row.storageUsedBytes, 2)
+            ? formatBytes(row.storageUsedBytes, 'decimal', 2)
             : '—'}
         </TableCell>
 

--- a/apps/studio/components/interfaces/Organization/Backups/RestoreBackupDialog.tsx
+++ b/apps/studio/components/interfaces/Organization/Backups/RestoreBackupDialog.tsx
@@ -64,7 +64,7 @@ export const RestoreBackupDialog = ({
           <DialogTitle>Restore backup</DialogTitle>
           <DialogDescription>
             {row && backup
-              ? `Restore ${backup.id} (${formatBytes(backup.sizeBytes, 2)})`
+              ? `Restore ${backup.id} (${formatBytes(backup.sizeBytes, 'decimal', 2)})`
               : 'Select a backup to restore.'}
           </DialogDescription>
         </DialogHeader>

--- a/apps/studio/components/interfaces/Organization/Usage/UsageSection/DatabaseSizeUsage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/UsageSection/DatabaseSizeUsage.tsx
@@ -76,7 +76,7 @@ const DatabaseSizeUsage = ({
             <div className="flex items-center justify-between">
               <p className="text-xs text-foreground-light">Max database size</p>
               <p className="text-xs">
-                {databaseSizeUsage?.usage ? formatBytes(databaseSizeUsage?.usage_original) : '-'}
+                {databaseSizeUsage?.usage ? formatBytes(databaseSizeUsage?.usage_original, 'decimal') : '-'}
               </p>
             </div>
           </div>
@@ -126,13 +126,13 @@ const DatabaseSizeUsage = ({
                       <div className="flex items-center h-6 gap-3">
                         <span className="text-foreground-light text-sm font-mono flex items-center gap-2">
                           <span className="text-foreground font-semibold font-mono -mt-[2px]">
-                            {formatBytes(project.usage)}
+                            {formatBytes(project.usage, 'decimal')}
                           </span>{' '}
                           Database Size
                         </span>
                         <InfoTooltip side="top">
                           <p>
-                            {formatBytes(project.usage)} GB database size as reported by Postgres.
+                            {formatBytes(project.usage, 'decimal')} database size as reported by Postgres.
                           </p>
                         </InfoTooltip>
                       </div>

--- a/apps/studio/components/interfaces/Project/utils.tsx
+++ b/apps/studio/components/interfaces/Project/utils.tsx
@@ -1,3 +1,5 @@
+import { formatBytes } from 'lib/helpers'
+
 // lib/resource-utils.ts
 export type ResourceKey =
   | 'milli_vcpu'
@@ -59,10 +61,8 @@ export function formatResource(key: string, raw: number | null | undefined): str
 
   if (value == null) return '—'
 
-  if (meta.unit === 'GiB' || meta.unit === 'GB') {
-    if (value < 10) return `${value.toFixed(2)} ${meta.unit}`
-    return `${Math.round(value)} ${meta.unit}`
-  }
+  if (meta.unit === 'GB') return formatBytes(raw, 'decimal', value < 10 ? 2 : 0)
+  if (meta.unit === 'GiB') return formatBytes(raw, 'binary', value < 10 ? 2 : 0)
 
   if (meta.unit === 'vCPU') {
     return value % 1 === 0 ? `${value.toFixed(0)} ${meta.unit}` : `${value.toFixed(1)} ${meta.unit}`

--- a/apps/studio/components/interfaces/ProjectAPIDocs/Content/Bucket.tsx
+++ b/apps/studio/components/interfaces/ProjectAPIDocs/Content/Bucket.tsx
@@ -42,7 +42,7 @@ const Bucket = ({ language, apikey, endpoint }: ContentProps) => {
         </p>
         <p className="text-sm text-foreground-light">
           Max file size limit:{' '}
-          {maxFileSizeLimit === null ? 'No limit' : `${formatBytes(maxFileSizeLimit)}`}
+          {maxFileSizeLimit === null ? 'No limit' : `${formatBytes(maxFileSizeLimit, 'decimal')}`}
         </p>
       </div>
 

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerColumn.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerColumn.tsx
@@ -266,7 +266,7 @@ const FileExplorerColumn = ({
       {snap.view === STORAGE_VIEWS.LIST && (
         <div className="shrink-0 rounded-b-md z-10 flex min-w-min items-center bg-panel-footer-light px-2.5 py-2 [[data-theme*=dark]_&]:bg-panel-footer-dark w-full">
           <p className="text-sm">
-            {formatBytes(columnItemsSize)} for {columnItems.length} items
+            {formatBytes(columnItemsSize, 'decimal')} for {columnItems.length} items
           </p>
         </div>
       )}

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRow.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerRow.tsx
@@ -276,7 +276,7 @@ const FileExplorerRow: ItemRenderer<StorageItem, FileExplorerRowProps> = ({
             : []),
         ]
 
-  const size = item.metadata ? formatBytes(item.metadata.size) : '-'
+  const size = item.metadata ? formatBytes(item.metadata.size, 'decimal') : '-'
   const mimeType = item.metadata ? item.metadata.mimetype : '-'
   const createdAt = item.created_at ? new Date(item.created_at).toLocaleString() : '-'
   const updatedAt = item.updated_at ? new Date(item.updated_at).toLocaleString() : '-'

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/PreviewPane.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/PreviewPane.tsx
@@ -134,7 +134,7 @@ const PreviewPane = () => {
 
   const width = 450
   const isOpen = !isEmpty(file)
-  const size = file.metadata ? formatBytes(file.metadata.size) : null
+  const size = file.metadata ? formatBytes(file.metadata.size, 'decimal') : null
   const mimeType = file.metadata ? file.metadata.mimetype : undefined
   const createdAt = file.created_at ? new Date(file.created_at).toLocaleString() : 'Unknown'
   const updatedAt = file.updated_at ? new Date(file.updated_at).toLocaleString() : 'Unknown'

--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
@@ -167,7 +167,7 @@ const StorageSettings = () => {
                               bytes.{' '}
                             </>
                           )}
-                          Maximum upload file size is {formatBytes(maxBytes)}.
+                          Maximum upload file size is {formatBytes(maxBytes, 'decimal')}.
                         </>
                       }
                     >

--- a/apps/studio/components/interfaces/UnifiedLogs/ServiceFlow/config/serviceFlowFields.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/ServiceFlow/config/serviceFlowFields.ts
@@ -534,11 +534,11 @@ export const storagePrimaryFields: BlockFieldConfig[] = [
           : null)
 
       if (contentType && contentLength) {
-        return `${contentType} - ${formatBytes(contentLength)}`
+        return `${contentType} - ${formatBytes(contentLength, 'decimal')}`
       } else if (contentType) {
         return contentType
       } else if (contentLength) {
-        return formatBytes(contentLength)
+        return formatBytes(contentLength, 'decimal')
       }
       return 'Unknown type'
     },

--- a/apps/studio/components/ui/Charts/ChartHeader.tsx
+++ b/apps/studio/components/ui/Charts/ChartHeader.tsx
@@ -69,7 +69,7 @@ const ChartHeader = ({
 
     if (shouldFormatBytes) {
       const bytesValue = isNetworkChart ? Math.abs(value) : value
-      return formatBytes(bytesValue, valuePrecision)
+      return formatBytes(bytesValue, 'decimal', valuePrecision)
     }
 
     return numberFormatter(value, valuePrecision)

--- a/apps/studio/components/ui/Charts/ComposedChart.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChart.tsx
@@ -211,7 +211,7 @@ export default function ComposedChart({
 
     if (shouldFormatBytes) {
       const bytesValue = isNetworkChart ? Math.abs(value) : value
-      return formatBytes(bytesValue, valuePrecision)
+      return formatBytes(bytesValue, 'decimal', valuePrecision)
     }
 
     return numberFormatter(value, valuePrecision)

--- a/apps/studio/components/ui/Charts/ComposedChart.utils.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChart.utils.tsx
@@ -186,7 +186,7 @@ const CustomTooltip = ({
           </span>
           <span className="ml-3.5 flex items-end gap-1">
             {shouldFormatBytes
-              ? formatBytes(isNetworkChart ? Math.abs(entry.value) : entry.value, valuePrecision)
+              ? formatBytes(isNetworkChart ? Math.abs(entry.value) : entry.value, 'decimal', valuePrecision)
               : numberFormatter(entry.value, valuePrecision)}
             {isPercentage ? '%' : ''}
             {format === 'ms' ? 'ms' : ''}
@@ -221,7 +221,7 @@ const CustomTooltip = ({
               <div className="flex items-end gap-1">
                 <span className="text-base">
                   {shouldFormatBytes
-                    ? formatBytes(total as number, valuePrecision)
+                    ? formatBytes(total as number, 'decimal', valuePrecision)
                     : numberFormatter(total as number, valuePrecision)}
                   {isPercentage ? '%' : ''}
                   {format === 'ms' ? 'ms' : ''}

--- a/apps/studio/data/reports/database-charts.ts
+++ b/apps/studio/data/reports/database-charts.ts
@@ -243,7 +243,7 @@ export const getReportAttributesV2: (
       valuePrecision: 2,
       YAxisProps: {
         width: 75,
-        tickFormatter: (value: any) => formatBytes(value, 2),
+        tickFormatter: (value: any) => formatBytes(value, 'binary', 2),
       },
       attributes: [
         {
@@ -520,7 +520,7 @@ export const getReportAttributesV2: (
       showGrid: true,
       YAxisProps: {
         width: 65,
-        tickFormatter: (value: any) => formatBytes(value, 1),
+        tickFormatter: (value: any) => formatBytes(value, 'decimal', 1),
       },
       hideChartType: false,
       defaultChartStyle: 'line',

--- a/apps/studio/lib/helpers.test.ts
+++ b/apps/studio/lib/helpers.test.ts
@@ -119,16 +119,36 @@ describe('propsAreEqual', () => {
 })
 
 describe('formatBytes', () => {
-  it('should return the formatted bytes', () => {
-    const result = formatBytes(1024)
+  it('should return the formatted bytes in binary mode', () => {
+    const result = formatBytes(1024, 'binary')
 
-    expect(result).toEqual('1 KB')
+    expect(result).toEqual('1 KiB')
   })
 
-  it('should return the formatted bytes in MB', () => {
-    const result = formatBytes(1024 * 1024)
+  it('should return the formatted bytes in MiB', () => {
+    const result = formatBytes(1024 * 1024, 'binary')
 
-    expect(result).toEqual('1 MB')
+    expect(result).toEqual('1 MiB')
+  })
+
+  it('should return 1 GB in decimal mode for 1_000_000_000 bytes', () => {
+    expect(formatBytes(1_000_000_000, 'decimal')).toEqual('1 GB')
+  })
+
+  it('should return 1.5 GB in decimal mode for 1_500_000_000 bytes', () => {
+    expect(formatBytes(1_500_000_000, 'decimal')).toEqual('1.5 GB')
+  })
+
+  it('should return 500 MB in decimal mode for 500_000_000 bytes', () => {
+    expect(formatBytes(500_000_000, 'decimal')).toEqual('500 MB')
+  })
+
+  it('should return 0 B in decimal mode for 0 bytes', () => {
+    expect(formatBytes(0, 'decimal')).toEqual('0 B')
+  })
+
+  it('should return -1 GB in decimal mode for negative 1_000_000_000 bytes', () => {
+    expect(formatBytes(-1_000_000_000, 'decimal')).toEqual('-1 GB')
   })
 })
 

--- a/apps/studio/lib/helpers.ts
+++ b/apps/studio/lib/helpers.ts
@@ -114,20 +114,27 @@ export const propsAreEqual = (prevProps: any, nextProps: any) => {
 
 export const formatBytes = (
   bytes: any,
+  mode: 'binary' | 'decimal',
   decimals = 2,
-  size?: 'bytes' | 'KB' | 'MB' | 'GB' | 'TB' | 'PB' | 'EB' | 'ZB' | 'YB'
+  size?: 'bytes' | 'KiB' | 'MiB' | 'GiB' | 'TiB' | 'PiB' | 'KB' | 'MB' | 'GB' | 'TB' | 'PB'
 ) => {
-  const k = 1024
+  const k = mode === 'decimal' ? 1000 : 1024
   const dm = decimals < 0 ? 0 : decimals
-  const sizes = ['bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
+  const sizes =
+    mode === 'decimal'
+      ? ['B', 'KB', 'MB', 'GB', 'TB', 'PB']
+      : ['bytes', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB']
 
-  if (bytes === 0 || bytes === undefined) return size !== undefined ? `0 ${size}` : '0 bytes'
+  if (bytes === 0 || bytes === undefined) return size !== undefined ? `0 ${size}` : `0 ${sizes[0]}`
 
   // Handle negative values
   const isNegative = bytes < 0
   const absBytes = Math.abs(bytes)
 
-  const i = size !== undefined ? sizes.indexOf(size) : Math.floor(Math.log(absBytes) / Math.log(k))
+  const i =
+    size !== undefined
+      ? sizes.indexOf(size)
+      : Math.min(Math.floor(Math.log(absBytes) / Math.log(k)), sizes.length - 1)
   const formattedValue = parseFloat((absBytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i]
 
   return isNegative ? '-' + formattedValue : formattedValue

--- a/apps/studio/pages/org/[slug]/project/[ref]/branch/[branch]/reports/database.tsx
+++ b/apps/studio/pages/org/[slug]/project/[ref]/branch/[branch]/reports/database.tsx
@@ -269,7 +269,7 @@ const DatabaseUsage = () => {
                 <div className="col-span-4 inline-grid grid-cols-12 gap-12 w-full mt-5">
                   <div className="grid gap-2 col-span-4 xl:col-span-2">
                     <h5>Space used</h5>
-                    <span className="text-lg">{formatBytes(databaseSizeBytes, 2, 'GB')}</span>
+                    <span className="text-lg">{formatBytes(databaseSizeBytes, 'decimal', 2, 'GB')}</span>
                   </div>
                   <div className="grid gap-2 col-span-4 xl:col-span-3">
                     <h5>Provisioned disk size</h5>
@@ -320,7 +320,7 @@ const DatabaseUsage = () => {
                             {object.schema_name}.{object.relname}
                           </Table.td>
                           <Table.td>
-                            {formatBytes(object.table_size)} ({percentage}%)
+                            {formatBytes(object.table_size, 'decimal')} ({percentage}%)
                           </Table.td>
                         </Table.tr>
                       )


### PR DESCRIPTION
We display a lot of data sizes in the frontend, it's important to handle this correctly and consistently. The `formatBytes` helper used to always use binary (base 1024) units, in some places incorrectly. In other places manual calculations were used to calculate decimal units. The updated formatBytes helper takes an additional `decimal`/`binary` argument that allows to toggle between both modes, giving `XB`/`XiB` units respectively. Using the `i`-infix ensures there is no ambiguity, yet we still need to ensure to consistently use binary units for memory only.